### PR TITLE
Fix cut

### DIFF
--- a/tools/scene_cut/cut.py
+++ b/tools/scene_cut/cut.py
@@ -29,7 +29,7 @@ def process_single_row(row, args, log_name=None):
     if not (timestamp.startswith("[") and timestamp.endswith("]")):
         return False
     scene_list = eval(timestamp)
-    scene_list = [(FrameTimecode(s, fps=1), FrameTimecode(t, fps=1)) for s, t in scene_list]
+    scene_list = [(FrameTimecode(s, fps=args.target_fps), FrameTimecode(t, fps=args.target_fps)) for s, t in scene_list]
     split_video(
         video_path,
         scene_list,


### PR DESCRIPTION
Otherwise all the video clips are cut at seconds, including frame from the next scene. Example: 

Before fix

https://github.com/davidh-lambda/Open-Sora/assets/15967400/4b5c8e22-371f-4498-b624-b5e793d14aa3

After fix

https://github.com/davidh-lambda/Open-Sora/assets/15967400/2ed76d94-712e-4335-bf14-6cf18d9b0d86

