### PR TITLE
Fixes issue with fetching info for caption CSV

### DIFF
--- a/scripts/data_process.py
+++ b/scripts/data_process.py
@@ -86,7 +86,7 @@ def main(args):
         command = f"python -m tools.caption.caption_par {root_meta / f'meta_clips_info_fmin1_aes_aesmin{args.aes_score}.csv'} --prompt {args.prompt} --key {args.key} --model {args.caption} --num-p {args.num_p}"
         check_status(command, "caption_gpt4o")
 
-    command = f"python -m tools.datasets.datautil {root_meta / f'meta_clips_info_fmin1_aes_aesmin{args.aes_score}_caption.csv'} --clean-caption --refine-llm-caption --remove-empty-caption --output {root_meta / 'meta_clips_caption_cleaned.csv'}"
+    command = f"python -m tools.datasets.datautil {root_meta / f'meta_clips_info_fmin1_aes_aesmin{args.aes_score}_caption.csv'} --video-info --clean-caption --refine-llm-caption --remove-empty-caption --output {root_meta / 'meta_clips_caption_cleaned.csv'}"
     check_status(command, "datautil clean-caption")
 
 

--- a/tools/datasets/datautil.py
+++ b/tools/datasets/datautil.py
@@ -74,10 +74,10 @@ def get_info(path):
 
 def get_video_info(path):
     try:
-        vframes, _, _ = torchvision.io.read_video(filename=path, pts_unit="sec", output_format="TCHW")
+        vframes, _, info = torchvision.io.read_video(filename=path, pts_unit="sec", output_format="TCHW")
         num_frames, height, width = vframes.shape[0], vframes.shape[2], vframes.shape[3]
         aspect_ratio = height / width
-        fps = np.nan
+        fps = info['video_fps']
         resolution = height * width
         return num_frames, height, width, aspect_ratio, fps, resolution
     except:
@@ -438,6 +438,8 @@ def main(args):
         assert "path" in data.columns
         data["text"] = apply(data["path"], load_caption, ext=args.load_caption)
     if args.info:
+        if "path" not in data.columns and "image" in data.columns:
+            data.rename(columns={"image": "path"}, inplace=True)
         info = apply(data["path"], get_info)
         (
             data["num_frames"],
@@ -448,6 +450,8 @@ def main(args):
             data["resolution"],
         ) = zip(*info)
     if args.video_info:
+        if "path" not in data.columns and "video" in data.columns:
+            data.rename(columns={"video": "path"}, inplace=True)
         info = apply(data["path"], get_video_info)
         (
             data["num_frames"],


### PR DESCRIPTION
- Added `--video-info` arg to the last `tools.datasets.datautil` command
- Fixed an issue with the datautil script where we look for 'path' column, but caption CSV has 'image' or 'video' column instead, renames the column in the CSV to 'path'
- Fixed `get_video_info` so the fps of videos is properly fetched and used in the output CSV